### PR TITLE
Fix Grafana datasource UID for dashboard compatibility

### DIFF
--- a/src/Pi4/grafana/provisioning/datasources/prometheus.yml
+++ b/src/Pi4/grafana/provisioning/datasources/prometheus.yml
@@ -7,3 +7,4 @@ datasources:
     url: http://prometheus:9090
     isDefault: true
     editable: true
+    uid: DS_PROMETHEUS


### PR DESCRIPTION
- Add uid: DS_PROMETHEUS to Prometheus datasource configuration
- Resolves dashboard error: DS_PROMETHUS not found
- Ensures proper datasource mapping for imported dashboards