### PR TITLE
cloud-edge: fix Cilium gateway privileged port binding

### DIFF
--- a/cloud-edge/k3s-services/cilium.tf
+++ b/cloud-edge/k3s-services/cilium.tf
@@ -50,6 +50,40 @@ resource "helm_release" "cilium" {
         }
       }
 
+      securityContext = {
+        capabilities = {
+          ciliumAgent = [
+            "CHOWN",
+            "KILL",
+            "NET_ADMIN",
+            "NET_RAW",
+            "IPC_LOCK",
+            "SYS_MODULE",
+            "SYS_ADMIN",
+            "SYS_RESOURCE",
+            "DAC_OVERRIDE",
+            "FOWNER",
+            "SETGID",
+            "SETUID",
+            "SYSLOG",
+            "NET_BIND_SERVICE"
+          ]
+        }
+      }
+
+      envoy = {
+        securityContext = {
+          capabilities = {
+            envoy = [
+              "NET_ADMIN",
+              "SYS_ADMIN",
+              "NET_BIND_SERVICE"
+            ]
+            keepCapNetBindService = true
+          }
+        }
+      }
+
       l2announcements = {
         enabled = false
       }

--- a/cloud-edge/nixos/hosts/oracle-edge/default.nix
+++ b/cloud-edge/nixos/hosts/oracle-edge/default.nix
@@ -15,10 +15,6 @@
     systemd-boot.enable = true;
   };
 
-  boot.kernel.sysctl = {
-    "net.ipv4.ip_unprivileged_port_start" = 80;
-  };
-
   networking = {
     hostName = "oracle-edge";
     useDHCP = false;


### PR DESCRIPTION
## Summary
- enable Cilium-scoped NET_BIND_SERVICE capabilities for Gateway API hostNetwork listeners on ports 80/443
- set `envoy.securityContext.capabilities.keepCapNetBindService = true`
- remove global Nix sysctl override `net.ipv4.ip_unprivileged_port_start = 80`

## Why
Gateway was `Accepted=True` but `Programmed=False` with `AddressNotAssigned` while using hostNetwork listeners on privileged ports. This change adopts a scoped capability-based approach instead of globally relaxing privileged port binding on the node.

## Scope
- cloud-edge/k3s-services/cilium.tf
- cloud-edge/nixos/hosts/oracle-edge/default.nix

## Validation
- terraform -chdir=cloud-edge/k3s-services validate: success
