### PR TITLE
cloud-edge: add hostNetwork gateway address workaround

### DIFF
--- a/.github/workflows/cloud-edge.yaml
+++ b/.github/workflows/cloud-edge.yaml
@@ -508,12 +508,16 @@ jobs:
 
       - name: Terraform Plan
         id: plan
+        env:
+          TF_VAR_gateway_private_ip: ${{ steps.edge.outputs.private_ip }}
         run: terraform plan -lock-timeout=10m -out .planfile -input=false
 
       - name: Terraform Apply
         if: |
           (github.ref == 'refs/heads/main' && github.event_name == 'push') ||
           (github.event_name == 'workflow_dispatch')
+        env:
+          TF_VAR_gateway_private_ip: ${{ steps.edge.outputs.private_ip }}
         run: terraform apply -lock-timeout=10m -auto-approve -input=false
 
       # Cluster Mesh bootstrap: connect the two Cilium clusters (idempotent)

--- a/cloud-edge/k3s-services/gateway-api.tf
+++ b/cloud-edge/k3s-services/gateway-api.tf
@@ -30,57 +30,67 @@ resource "kubectl_manifest" "cloud_gateway" {
       name      = "cloud-gateway"
       namespace = kubernetes_namespace_v1.gateway.metadata[0].name
     }
-    spec = {
-      gatewayClassName = "cilium"
-      listeners = [
-        # HTTP listener for ACME challenges and redirects
-        {
-          name     = "http"
-          protocol = "HTTP"
-          port     = 80
-          allowedRoutes = {
-            namespaces = {
-              from = "All"
-            }
-          }
-        },
-        # TLS passthrough for relay services
-        {
-          name     = "relay-passthrough"
-          protocol = "TLS"
-          port     = 443
-          hostname = "*.relay.lippok.dev"
-          tls = {
-            mode = "Passthrough"
-          }
-          allowedRoutes = {
-            namespaces = {
-              from = "All"
-            }
-          }
-        },
-        # HTTPS termination for cloud-hosted services
-        {
-          name     = "cloud-https"
-          protocol = "HTTPS"
-          port     = 443
-          hostname = "*.cloud.lippok.dev"
-          tls = {
-            mode = "Terminate"
-            certificateRefs = [
-              {
-                name = "wildcard-cloud-lippok-dev-tls"
+    spec = merge(
+      {
+        gatewayClassName = "cilium"
+        listeners = [
+          # HTTP listener for ACME challenges and redirects
+          {
+            name     = "http"
+            protocol = "HTTP"
+            port     = 80
+            allowedRoutes = {
+              namespaces = {
+                from = "All"
               }
-            ]
-          }
-          allowedRoutes = {
-            namespaces = {
-              from = "All"
+            }
+          },
+          # TLS passthrough for relay services
+          {
+            name     = "relay-passthrough"
+            protocol = "TLS"
+            port     = 443
+            hostname = "*.relay.lippok.dev"
+            tls = {
+              mode = "Passthrough"
+            }
+            allowedRoutes = {
+              namespaces = {
+                from = "All"
+              }
+            }
+          },
+          # HTTPS termination for cloud-hosted services
+          {
+            name     = "cloud-https"
+            protocol = "HTTPS"
+            port     = 443
+            hostname = "*.cloud.lippok.dev"
+            tls = {
+              mode = "Terminate"
+              certificateRefs = [
+                {
+                  name = "wildcard-cloud-lippok-dev-tls"
+                }
+              ]
+            }
+            allowedRoutes = {
+              namespaces = {
+                from = "All"
+              }
             }
           }
-        }
-      ]
-    }
+        ]
+      },
+      var.gateway_private_ip != "" ? {
+        addresses = [
+          {
+            type  = "IPAddress"
+            value = var.gateway_private_ip
+          }
+        ]
+      } : {}
+    )
   })
 
   depends_on = [

--- a/cloud-edge/k3s-services/variables.tf
+++ b/cloud-edge/k3s-services/variables.tf
@@ -37,3 +37,9 @@ variable "acme_email" {
   type        = string
   default     = ""
 }
+
+variable "gateway_private_ip" {
+  description = "Optional private node IP to set in Gateway spec.addresses (workaround for Cilium hostNetwork AddressNotAssigned status)"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Work around Cilium hostNetwork Gateway AddressNotAssigned status by allowing explicit gateway private IP in Gateway spec.addresses and wiring TF_VAR_gateway_private_ip from edge workflow output.