### PR TITLE
cilium: lower MTU to 1200 for clustermesh DoH reliability

### DIFF
--- a/03-services/cilium.tf
+++ b/03-services/cilium.tf
@@ -11,7 +11,7 @@ resource "helm_release" "cilium" {
       kubeProxyReplacement = "true"
       k8sServiceHost       = "127.0.0.1"
       k8sServicePort       = 7445
-      MTU                  = 1370
+      MTU                  = 1200
       ipam = {
         mode = "kubernetes"
       }

--- a/cloud-edge/k3s-services/cilium.tf
+++ b/cloud-edge/k3s-services/cilium.tf
@@ -13,7 +13,7 @@ resource "helm_release" "cilium" {
       kubeProxyReplacement = "true"
       k8sServiceHost       = "127.0.0.1"
       k8sServicePort       = 6443
-      MTU                  = 1370
+      MTU                  = 1200
       devices              = "eth+ wg+"
       ipam = {
         mode = "kubernetes"


### PR DESCRIPTION
## Summary
- lower Cilium MTU from `1370` to `1200` in:
  - `03-services/cilium.tf`
  - `cloud-edge/k3s-services/cilium.tf`

## Why
DoH relay traffic over ClusterMesh was timing out despite routes/resources being present. Diagnostics showed path-MTU constraints between cloud-edge and homelab pod IPs (DF ping succeeded at 1250 payload, failed at 1300). With overlay overhead, MTU 1370 is too high for this path and can blackhole larger packets/TLS handshakes.

## Validation
- `terraform -chdir=03-services validate` -> success
- `terraform -chdir=cloud-edge/k3s-services validate` -> success
