### PR TITLE
fix: raise Cilium MTU to 1280

### DIFF
--- a/03-services/cilium.tf
+++ b/03-services/cilium.tf
@@ -11,7 +11,7 @@ resource "helm_release" "cilium" {
       kubeProxyReplacement = "true"
       k8sServiceHost       = "127.0.0.1"
       k8sServicePort       = 7445
-      MTU                  = 1200
+      MTU                  = 1280
       ipam = {
         mode = "kubernetes"
       }

--- a/cloud-edge/k3s-services/cilium.tf
+++ b/cloud-edge/k3s-services/cilium.tf
@@ -13,7 +13,7 @@ resource "helm_release" "cilium" {
       kubeProxyReplacement = "true"
       k8sServiceHost       = "127.0.0.1"
       k8sServicePort       = 6443
-      MTU                  = 1200
+      MTU                  = 1280
       devices              = "eth+ wg+"
       ipam = {
         mode = "kubernetes"


### PR DESCRIPTION
## Why\nThe previous MTU 1200 was too aggressive and coincided with control-plane/API instability reports.\n\n## What\n- Set Cilium MTU to 1280 in homelab services\n- Set Cilium MTU to 1280 in cloud-edge k3s-services\n\n## Notes\n1280 keeps MTU constrained for mesh paths while avoiding the lower 1200 setting.