### PR TITLE
ci: stabilize 03-services over direct Tailscale path

### DIFF
--- a/.github/workflows/03-services.yaml
+++ b/.github/workflows/03-services.yaml
@@ -56,53 +56,6 @@ jobs:
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:ci
 
-      - name: Route Kubernetes API Through Edge Tunnel
-        env:
-          OCI_EDGE_HOST: "152.70.41.15"
-          KUBE_API_HOST: "10.10.1.60"
-          OCI_SSH_PRIVATE_KEY: ${{ secrets.OCI_SSH_PRIVATE_KEY }}
-        run: |
-          set -euo pipefail
-          if [ -z "${OCI_SSH_PRIVATE_KEY:-}" ]; then
-            echo "::error::Missing required secret OCI_SSH_PRIVATE_KEY"
-            exit 1
-          fi
-
-          install -d -m 700 "${HOME}/.ssh"
-          printf '%s\n' "$OCI_SSH_PRIVATE_KEY" > "${HOME}/.ssh/oci_edge_ci"
-          chmod 600 "${HOME}/.ssh/oci_edge_ci"
-
-          SOCK="/tmp/oci-edge-kubeapi.sock"
-          echo "KUBE_TUNNEL_SOCK=${SOCK}" >> "$GITHUB_ENV"
-          echo "KUBE_API_HOST=${KUBE_API_HOST}" >> "$GITHUB_ENV"
-
-          ssh-keyscan -H "$OCI_EDGE_HOST" >> "${HOME}/.ssh/known_hosts" 2>/dev/null || true
-
-          ssh \
-            -i "${HOME}/.ssh/oci_edge_ci" \
-            -o IdentitiesOnly=yes \
-            -o StrictHostKeyChecking=accept-new \
-            -o ExitOnForwardFailure=yes \
-            -o ServerAliveInterval=30 \
-            -o ServerAliveCountMax=3 \
-            -M -S "$SOCK" -fN \
-            -L 127.0.0.1:16443:${KUBE_API_HOST}:6443 \
-            root@"$OCI_EDGE_HOST"
-
-          IPTABLES_BIN="$(command -v iptables || true)"
-          if [ -z "$IPTABLES_BIN" ]; then
-            echo "::error::iptables is required on the runner"
-            exit 1
-          fi
-
-          sudo "$IPTABLES_BIN" -t nat -C OUTPUT -p tcp -d "${KUBE_API_HOST}" --dport 6443 -j DNAT --to-destination 127.0.0.1:16443 2>/dev/null || \
-            sudo "$IPTABLES_BIN" -t nat -A OUTPUT -p tcp -d "${KUBE_API_HOST}" --dport 6443 -j DNAT --to-destination 127.0.0.1:16443
-
-          echo "Active NAT rule:"
-          sudo "$IPTABLES_BIN" -t nat -S OUTPUT | grep "${KUBE_API_HOST}.*6443" || true
-
-          echo "SSH tunnel and NAT redirection configured"
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -169,18 +122,3 @@ jobs:
           (github.ref == 'refs/heads/main' && github.event_name == 'push') ||
           (github.event_name == 'workflow_dispatch' && inputs.apply == true)
         run: terraform apply -parallelism=1 -lock-timeout=10m -auto-approve -input=false
-
-      - name: Cleanup Kubernetes API Tunnel
-        if: always()
-        run: |
-          set +e
-          KUBE_API_HOST="${KUBE_API_HOST:-10.10.1.60}"
-
-          IPTABLES_BIN="$(command -v iptables || true)"
-          if [ -n "$IPTABLES_BIN" ]; then
-            sudo "$IPTABLES_BIN" -t nat -D OUTPUT -p tcp -d "${KUBE_API_HOST}" --dport 6443 -j DNAT --to-destination 127.0.0.1:16443 2>/dev/null || true
-          fi
-
-          if [ -n "${KUBE_TUNNEL_SOCK:-}" ] && [ -S "${KUBE_TUNNEL_SOCK}" ]; then
-            ssh -S "${KUBE_TUNNEL_SOCK}" -O exit root@152.70.41.15 2>/dev/null || true
-          fi

--- a/.github/workflows/03-services.yaml
+++ b/.github/workflows/03-services.yaml
@@ -115,6 +115,12 @@ jobs:
       - name: Kubernetes API Preflight
         run: |
           set -euo pipefail
+          KUBECONFIG_PATH="${GITHUB_WORKSPACE}/03-services/kubeconfig.yaml"
+          if [ ! -f "$KUBECONFIG_PATH" ]; then
+            echo "::error::Missing kubeconfig at $KUBECONFIG_PATH"
+            exit 1
+          fi
+
           echo "Route to Kubernetes API:"
           ip route get 10.10.1.60 || true
 
@@ -128,7 +134,7 @@ jobs:
 
           echo "Checking repeated API reads"
           for i in $(seq 1 20); do
-            kubectl --kubeconfig kubeconfig.yaml get --raw=/version >/dev/null
+            kubectl --kubeconfig "$KUBECONFIG_PATH" get --raw=/version >/dev/null
           done
 
       - name: Terraform Plan

--- a/.github/workflows/03-services.yaml
+++ b/.github/workflows/03-services.yaml
@@ -85,9 +85,21 @@ jobs:
       - name: Terraform Validate
         run: terraform validate
 
+      - name: Kubernetes API Preflight
+        run: |
+          set -euo pipefail
+          echo "Route to Kubernetes API:"
+          ip route get 10.10.1.60 || true
+
+          echo "Checking TCP connectivity to 10.10.1.60:6443"
+          timeout 10 bash -lc 'cat < /dev/null > /dev/tcp/10.10.1.60/6443'
+
+          echo "Checking TLS handshake with Kubernetes API"
+          timeout 12 openssl s_client -connect 10.10.1.60:6443 -brief < /dev/null > /dev/null 2>&1
+
       - name: Terraform Plan
         id: plan
-        run: terraform plan -lock-timeout=10m -out .planfile -input=false
+        run: terraform plan -parallelism=1 -lock-timeout=10m -out .planfile -input=false
         continue-on-error: true
 
       - name: Comment Terraform Plan
@@ -107,4 +119,4 @@ jobs:
         if: |
           (github.ref == 'refs/heads/main' && github.event_name == 'push') ||
           (github.event_name == 'workflow_dispatch' && inputs.apply == true)
-        run: terraform apply -lock-timeout=10m -auto-approve -input=false
+        run: terraform apply -parallelism=1 -lock-timeout=10m -auto-approve -input=false

--- a/.github/workflows/03-services.yaml
+++ b/.github/workflows/03-services.yaml
@@ -56,6 +56,50 @@ jobs:
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:ci
 
+      - name: Route Kubernetes API Through Edge Tunnel
+        env:
+          OCI_EDGE_HOST: "152.70.41.15"
+          KUBE_API_HOST: "10.10.1.60"
+          OCI_SSH_PRIVATE_KEY: ${{ secrets.OCI_SSH_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${OCI_SSH_PRIVATE_KEY:-}" ]; then
+            echo "::error::Missing required secret OCI_SSH_PRIVATE_KEY"
+            exit 1
+          fi
+
+          install -d -m 700 "${HOME}/.ssh"
+          printf '%s\n' "$OCI_SSH_PRIVATE_KEY" > "${HOME}/.ssh/oci_edge_ci"
+          chmod 600 "${HOME}/.ssh/oci_edge_ci"
+
+          SOCK="/tmp/oci-edge-kubeapi.sock"
+          echo "KUBE_TUNNEL_SOCK=${SOCK}" >> "$GITHUB_ENV"
+          echo "KUBE_API_HOST=${KUBE_API_HOST}" >> "$GITHUB_ENV"
+
+          ssh-keyscan -H "$OCI_EDGE_HOST" >> "${HOME}/.ssh/known_hosts" 2>/dev/null || true
+
+          ssh \
+            -i "${HOME}/.ssh/oci_edge_ci" \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=accept-new \
+            -o ExitOnForwardFailure=yes \
+            -o ServerAliveInterval=30 \
+            -o ServerAliveCountMax=3 \
+            -M -S "$SOCK" -fN \
+            -L 127.0.0.1:16443:${KUBE_API_HOST}:6443 \
+            root@"$OCI_EDGE_HOST"
+
+          IPTABLES_BIN="$(command -v iptables || true)"
+          if [ -z "$IPTABLES_BIN" ]; then
+            echo "::error::iptables is required on the runner"
+            exit 1
+          fi
+
+          sudo "$IPTABLES_BIN" -t nat -C OUTPUT -p tcp -d "${KUBE_API_HOST}" --dport 6443 -j DNAT --to-destination 127.0.0.1:16443 2>/dev/null || \
+            sudo "$IPTABLES_BIN" -t nat -A OUTPUT -p tcp -d "${KUBE_API_HOST}" --dport 6443 -j DNAT --to-destination 127.0.0.1:16443
+
+          echo "SSH tunnel and NAT redirection configured"
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -95,7 +139,9 @@ jobs:
           timeout 10 bash -lc 'cat < /dev/null > /dev/tcp/10.10.1.60/6443'
 
           echo "Checking TLS handshake with Kubernetes API"
-          timeout 12 openssl s_client -connect 10.10.1.60:6443 -brief < /dev/null > /dev/null 2>&1
+          for i in 1 2 3; do
+            timeout 12 openssl s_client -connect 10.10.1.60:6443 -brief < /dev/null > /dev/null 2>&1
+          done
 
       - name: Terraform Plan
         id: plan
@@ -120,3 +166,18 @@ jobs:
           (github.ref == 'refs/heads/main' && github.event_name == 'push') ||
           (github.event_name == 'workflow_dispatch' && inputs.apply == true)
         run: terraform apply -parallelism=1 -lock-timeout=10m -auto-approve -input=false
+
+      - name: Cleanup Kubernetes API Tunnel
+        if: always()
+        run: |
+          set +e
+          KUBE_API_HOST="${KUBE_API_HOST:-10.10.1.60}"
+
+          IPTABLES_BIN="$(command -v iptables || true)"
+          if [ -n "$IPTABLES_BIN" ]; then
+            sudo "$IPTABLES_BIN" -t nat -D OUTPUT -p tcp -d "${KUBE_API_HOST}" --dport 6443 -j DNAT --to-destination 127.0.0.1:16443 2>/dev/null || true
+          fi
+
+          if [ -n "${KUBE_TUNNEL_SOCK:-}" ] && [ -S "${KUBE_TUNNEL_SOCK}" ]; then
+            ssh -S "${KUBE_TUNNEL_SOCK}" -O exit root@152.70.41.15 2>/dev/null || true
+          fi

--- a/.github/workflows/03-services.yaml
+++ b/.github/workflows/03-services.yaml
@@ -98,6 +98,9 @@ jobs:
           sudo "$IPTABLES_BIN" -t nat -C OUTPUT -p tcp -d "${KUBE_API_HOST}" --dport 6443 -j DNAT --to-destination 127.0.0.1:16443 2>/dev/null || \
             sudo "$IPTABLES_BIN" -t nat -A OUTPUT -p tcp -d "${KUBE_API_HOST}" --dport 6443 -j DNAT --to-destination 127.0.0.1:16443
 
+          echo "Active NAT rule:"
+          sudo "$IPTABLES_BIN" -t nat -S OUTPUT | grep "${KUBE_API_HOST}.*6443" || true
+
           echo "SSH tunnel and NAT redirection configured"
 
       - name: Setup Node.js

--- a/.github/workflows/03-services.yaml
+++ b/.github/workflows/03-services.yaml
@@ -115,12 +115,6 @@ jobs:
       - name: Kubernetes API Preflight
         run: |
           set -euo pipefail
-          KUBECONFIG_PATH="${GITHUB_WORKSPACE}/03-services/kubeconfig.yaml"
-          if [ ! -f "$KUBECONFIG_PATH" ]; then
-            echo "::error::Missing kubeconfig at $KUBECONFIG_PATH"
-            exit 1
-          fi
-
           echo "Route to Kubernetes API:"
           ip route get 10.10.1.60 || true
 
@@ -128,13 +122,8 @@ jobs:
           timeout 10 bash -lc 'cat < /dev/null > /dev/tcp/10.10.1.60/6443'
 
           echo "Checking TLS handshake with Kubernetes API"
-          for i in 1 2 3; do
+          for i in $(seq 1 10); do
             timeout 12 openssl s_client -connect 10.10.1.60:6443 -brief < /dev/null > /dev/null 2>&1
-          done
-
-          echo "Checking repeated API reads"
-          for i in $(seq 1 20); do
-            kubectl --kubeconfig "$KUBECONFIG_PATH" get --raw=/version >/dev/null
           done
 
       - name: Terraform Plan

--- a/.github/workflows/03-services.yaml
+++ b/.github/workflows/03-services.yaml
@@ -56,6 +56,33 @@ jobs:
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:ci
 
+      - name: Stabilize Kube API TCP MSS
+        run: |
+          set -euo pipefail
+          KUBE_API_HOST="10.10.1.60"
+          MSS_VALUE="1200"
+
+          # Enable kernel MTU probing to recover from PMTU blackholes on routed paths.
+          sudo sysctl -w net.ipv4.tcp_mtu_probing=1 >/dev/null || true
+
+          IPTABLES_BIN="$(command -v iptables || true)"
+          if [ -z "$IPTABLES_BIN" ]; then
+            echo "::error::iptables is required on the runner"
+            exit 1
+          fi
+
+          sudo "$IPTABLES_BIN" -t mangle -C OUTPUT \
+            -p tcp -d "${KUBE_API_HOST}" --dport 6443 \
+            --tcp-flags SYN,RST SYN \
+            -j TCPMSS --set-mss "${MSS_VALUE}" 2>/dev/null || \
+          sudo "$IPTABLES_BIN" -t mangle -A OUTPUT \
+            -p tcp -d "${KUBE_API_HOST}" --dport 6443 \
+            --tcp-flags SYN,RST SYN \
+            -j TCPMSS --set-mss "${MSS_VALUE}"
+
+          echo "Active MSS rule:"
+          sudo "$IPTABLES_BIN" -t mangle -S OUTPUT | grep "${KUBE_API_HOST}.*6443.*TCPMSS" || true
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -99,6 +126,11 @@ jobs:
             timeout 12 openssl s_client -connect 10.10.1.60:6443 -brief < /dev/null > /dev/null 2>&1
           done
 
+          echo "Checking repeated API reads"
+          for i in $(seq 1 20); do
+            kubectl --kubeconfig kubeconfig.yaml get --raw=/version >/dev/null
+          done
+
       - name: Terraform Plan
         id: plan
         run: terraform plan -parallelism=1 -lock-timeout=10m -out .planfile -input=false
@@ -122,3 +154,16 @@ jobs:
           (github.ref == 'refs/heads/main' && github.event_name == 'push') ||
           (github.event_name == 'workflow_dispatch' && inputs.apply == true)
         run: terraform apply -parallelism=1 -lock-timeout=10m -auto-approve -input=false
+
+      - name: Cleanup Kube API MSS Rule
+        if: always()
+        run: |
+          set +e
+          KUBE_API_HOST="10.10.1.60"
+          IPTABLES_BIN="$(command -v iptables || true)"
+          if [ -n "$IPTABLES_BIN" ]; then
+            sudo "$IPTABLES_BIN" -t mangle -D OUTPUT \
+              -p tcp -d "${KUBE_API_HOST}" --dport 6443 \
+              --tcp-flags SYN,RST SYN \
+              -j TCPMSS --set-mss 1200 2>/dev/null || true
+          fi


### PR DESCRIPTION
## Problem
`deploy-services / Terraform Services` intermittently fails with Kubernetes API TLS/header timeouts to `https://10.10.1.60:6443` over the direct Tailscale path.

## Changes
- Keep direct Tailscale path only (no OCI relay)
- Keep API preflight checks
- Keep reduced Terraform API concurrency (`-parallelism=1`)
- Add TCP MSS clamp (`1200`) for `10.10.1.60:6443` on runner OUTPUT mangle table
- Enable `net.ipv4.tcp_mtu_probing=1` on runner
- Add repeated API read probe before Terraform
- Cleanup mangle rule at job end

## Why
This targets PMTU/packetization instability on the runner-to-cluster route without introducing cloud dependency.
