### PR TITLE
rollback: restore main to 5535c79

### DIFF
--- a/03-services/cilium.tf
+++ b/03-services/cilium.tf
@@ -11,7 +11,7 @@ resource "helm_release" "cilium" {
       kubeProxyReplacement = "true"
       k8sServiceHost       = "127.0.0.1"
       k8sServicePort       = 7445
-      MTU                  = 1280
+      MTU                  = 1370
       ipam = {
         mode = "kubernetes"
       }

--- a/cloud-edge/k3s-services/cilium.tf
+++ b/cloud-edge/k3s-services/cilium.tf
@@ -13,7 +13,7 @@ resource "helm_release" "cilium" {
       kubeProxyReplacement = "true"
       k8sServiceHost       = "127.0.0.1"
       k8sServicePort       = 6443
-      MTU                  = 1280
+      MTU                  = 1370
       devices              = "eth+ wg+"
       ipam = {
         mode = "kubernetes"


### PR DESCRIPTION
Roll back main to commit 5535c793ad3f0d164bf354178214376b9939a1db.\n\nScope: revert Cilium MTU-related changes introduced after that commit.