### PR TITLE
fix(cloud-edge): switch cloud gateway from NLB to flexible LBaaS

### DIFF
--- a/cloud-edge/k3s-services/gateway-api.tf
+++ b/cloud-edge/k3s-services/gateway-api.tf
@@ -32,10 +32,19 @@ resource "kubectl_manifest" "cloud_gateway" {
     }
     spec = {
       gatewayClassName = "cilium"
+      # OCI CCM has no reserved-IP annotation for LBaaS; set via spec.loadBalancerIP, propagated here via Gateway addresses.
+      addresses = [
+        {
+          type  = "IPAddress"
+          value = local.cloud_edge.gateway_lb_reserved_ip
+        }
+      ]
       infrastructure = {
         annotations = {
-          "oci.oraclecloud.com/load-balancer-type" = "nlb"
-          "oci.oraclecloud.com/reserved-ips"       = local.cloud_edge.gateway_lb_reserved_ip
+          "oci.oraclecloud.com/load-balancer-type"                      = "lb"
+          "service.beta.kubernetes.io/oci-load-balancer-shape"          = "flexible"
+          "service.beta.kubernetes.io/oci-load-balancer-shape-flex-min" = "10"
+          "service.beta.kubernetes.io/oci-load-balancer-shape-flex-max" = "10"
         }
       }
       listeners = [


### PR DESCRIPTION
## Summary

- Flips `cloud-gateway` from OCI NLB to OCI LBaaS (flexible shape, 10/10 Mbps = Always-Free tier).
- Attaches the existing reserved public IP (`oci_core_public_ip.gateway_lb`) via `spec.addresses` on the Gateway instead of the `oci.oraclecloud.com/reserved-ips` annotation.

## Why

The cloud-gateway `LoadBalancer` Service has been stuck in `EXTERNAL-IP: <pending>` since the NLB switch. CCM kept retrying `CreateNetworkLoadBalancer` and getting `HTTP 404 NotAuthorizedOrNotFound`. Root cause verified by reproducing the call manually via `oci nlb network-load-balancer create` with Instance Principal auth:

- With `--reserved-ips '[{"id":"ocid1.publicip..."}]'` → 404 NotAuthorizedOrNotFound.
- Without `--reserved-ips` → NLB created successfully.

IAM, compartment, subnet, and the reserved IP itself all check out individually. The 404 is OCI's way of saying "no **BYOIP** public IP with that OCID exists in this tenancy" — OCI NLB's `reservedIps` field only accepts BYOIP addresses (Oracle docs: _Reserved IP support for public NLB_), while `oci_core_public_ip lifetime=RESERVED` gives a standard-pool reserved IP. Not a config bug, an OCI product restriction.

LBaaS (flexible) has no such restriction — it accepts standard reserved IPs, and a 10 Mbps flexible LB is part of the Always-Free tier, so the $0/month property is preserved.

## Changes

Only [cloud-edge/k3s-services/gateway-api.tf](cloud-edge/k3s-services/gateway-api.tf):

| Before | After |
|---|---|
| `oci.oraclecloud.com/load-balancer-type: nlb` | `oci.oraclecloud.com/load-balancer-type: lb` |
| `oci.oraclecloud.com/reserved-ips: <ip>` annotation | `spec.addresses[0] = IPAddress <ip>` |
| — | `service.beta.kubernetes.io/oci-load-balancer-shape: flexible` |
| — | `service.beta.kubernetes.io/oci-load-balancer-shape-flex-min: "10"` |
| — | `service.beta.kubernetes.io/oci-load-balancer-shape-flex-max: "10"` |

Why `spec.addresses` instead of an annotation: OCI CCM (verified against `load_balancer_spec.go` at tag v1.30.0) has **no** `reserved-ips` annotation for LBaaS. It reads `spec.loadBalancerIP` on the Service and resolves IP → OCID via `GetPublicIpByIpAddress`. Cilium Gateway propagates `spec.addresses` → `spec.loadBalancerIP`, so the Gateway-API-idiomatic field is what we want.

## Reviewer notes

- IAM in `cloud-edge/iam.tf` already grants `manage load-balancers` (for LBaaS) in addition to `manage network-load-balancers`, so no IAM change is required. Both are kept to avoid re-apply churn if we ever switch back.
- The running CCM on the cluster currently has a manually-patched image (`ghcr.io/finnpl/cloud-provider-oci-arm64:v1.34.0-reserved-ips.1`, applied via `kubectl set image` — drift from Terraform). That fork was built to add `reservedIps` to NLB create calls, but OCI rejects the request at the API layer regardless of CCM version, so it's not useful. Next `tofu apply` will revert it to the TF-pinned upstream `ghcr.io/oracle/cloud-provider-oci:v1.30.0`, which ships `linux/amd64`+`linux/arm64` and handles LBaaS reserved IPs natively. Expected and desired.
- The reserved IP `150.230.156.112` is preserved; no DNS or client-side changes needed.

## Test plan

- [ ] `tofu plan` shows only `kubectl_manifest.cloud_gateway` + `kubectl_manifest.ccm_deployment` (image revert) changes.
- [ ] `tofu apply` succeeds.
- [ ] `kubectl -n gateway get svc cilium-gateway-cloud-gateway -w` reaches `EXTERNAL-IP: 150.230.156.112`.
- [ ] `kubectl -n gateway get gateway cloud-gateway -o jsonpath='{.status.listeners[*].conditions[?(@.type=="Programmed")].status}'` returns `True True True`.
- [ ] `openssl s_client -connect 150.230.156.112:443 -servername foo.cloud.lippok.dev </dev/null` returns the wildcard cert from cert-manager.
- [ ] `curl -kv --resolve dns.relay.lippok.dev:443:150.230.156.112 https://dns.relay.lippok.dev/dns-query -H 'accept: application/dns-message'` — if this succeeds, the separate ingress-source-to-ServiceImport concern from earlier is also resolved and no relay pod is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)