### PR TITLE
fix(external-dns): exclude RFC1918 from published targets

### DIFF
--- a/cloud-edge/k3s-services/external-dns.tf
+++ b/cloud-edge/k3s-services/external-dns.tf
@@ -59,6 +59,14 @@ resource "helm_release" "external_dns" {
       policy        = "sync"
       txtOwnerId    = "cloud-edge"
       txtPrefix     = "extdns-"
+      # OCI NLB publishes both the public and the private VCN IP in
+      # Service.status.loadBalancer.ingress. Filter out RFC1918 so only
+      # the public NLB IP ends up in Cloudflare.
+      extraArgs = [
+        "--exclude-target-net=10.0.0.0/8",
+        "--exclude-target-net=172.16.0.0/12",
+        "--exclude-target-net=192.168.0.0/16",
+      ]
     })
   ]
 


### PR DESCRIPTION
## Problem
After merging #505, `doh.relay.lippok.dev` resolves to both the public NLB IP **and** the private VCN IP, e.g.:

\`\`\`
$ dig +short doh.relay.lippok.dev @1.1.1.1
10.70.1.94
141.147.6.225
\`\`\`

OCI NLB populates `Service.status.loadBalancer.ingress` with **both** the public and private addresses:
\`\`\`yaml
status:
  loadBalancer:
    ingress:
    - ip: 141.147.6.225
    - ip: 10.70.1.94
\`\`\`
external-dns reads both and publishes both to Cloudflare.

## Fix
Pass `--exclude-target-net` for the RFC1918 ranges via the chart's `extraArgs`, so only the public IP is selected as a record target. No new TF variables, no new dependencies.

## Test plan
- [ ] After apply: `dig +short doh.relay.lippok.dev @1.1.1.1` returns only the public NLB IP (141.147.6.225 at the moment).
- [ ] external-dns logs show `Deleting A record` for `10.70.1.94` (removed since it no longer matches the target set).
- [ ] DoH probe through the public IP completes TLS handshake (separate known issue — the TLS passthrough upstream from Envoy to the homelab DNS pod over cluster mesh is still broken, tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)