### PR TITLE
fix(cloud-edge): cascade instance replacement on VCN change

### DIFF
--- a/cloud-edge/compute.tf
+++ b/cloud-edge/compute.tf
@@ -57,12 +57,15 @@ resource "oci_core_instance" "edge" {
     )
   }
 
-  # Prevent replacement after nixos-anywhere has installed NixOS
+  # Prevent replacement after nixos-anywhere has installed NixOS, but force
+  # replacement when the VCN changes — the compute's VNIC pins the old subnet
+  # and blocks subnet destroy with a 409-Conflict otherwise.
   lifecycle {
     ignore_changes = [
       availability_domain,
       source_details[0].source_id,
       metadata,
     ]
+    replace_triggered_by = [oci_core_vcn.edge]
   }
 }

--- a/cloud-edge/compute.tf
+++ b/cloud-edge/compute.tf
@@ -57,9 +57,6 @@ resource "oci_core_instance" "edge" {
     )
   }
 
-  # Prevent replacement after nixos-anywhere has installed NixOS, but force
-  # replacement when the VCN changes — the compute's VNIC pins the old subnet
-  # and blocks subnet destroy with a 409-Conflict otherwise.
   lifecycle {
     ignore_changes = [
       availability_domain,


### PR DESCRIPTION
## Summary
- The CIDR migration apply failed with \`409-Conflict, The Subnet references the service VNIC\` after 10+ min of polling. The compute instance's VNIC pins the subnet, blocking destroy.
- Add \`replace_triggered_by = [oci_core_vcn.edge]\` to the instance so a VCN change cascades into instance replacement, making the destroy order \`instance → subnet → VCN update → new subnet → new instance\`.

## Recovery for the in-flight apply
After this lands:
1. Terminate \`oracle-edge\` manually in the OCI console (releases the VNIC that's currently blocking subnet destroy).
2. Rerun \`terraform apply\` — TF re-plans with the new lifecycle block and cascades cleanly.

## Test plan
- [ ] After merge + manual instance termination, apply completes the 10.70 → 10.75 CIDR migration end-to-end.
- [ ] On a future no-op apply, no spurious instance replacement is triggered (the \`replace_triggered_by\` only fires on actual VCN attribute changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)