### PR TITLE
fix(cloud-edge): bump VCN to 10.80 + sentinel to force VCN replacement on CIDR change

### DIFF
--- a/02-infrastructure/variables.tf
+++ b/02-infrastructure/variables.tf
@@ -285,7 +285,7 @@ variable "mesh_wg_peer_endpoint" {
 variable "cloud_vcn_cidr" {
   description = "CIDR of the OCI cloud-edge VCN (routed through WG tunnel)"
   type        = string
-  default     = "10.75.1.0/24"
+  default     = "10.80.1.0/24"
 }
 
 variable "postgres_root_password" {

--- a/cloud-edge/network.tf
+++ b/cloud-edge/network.tf
@@ -1,8 +1,21 @@
+# OCI's UpdateVcn API treats cidr_blocks as updateable in-place, so a CIDR
+# change keeps the same VCN OCID. Empirically that "VCN reuse" leaves new
+# instances with sshd that accepts TCP but never exchanges the SSH banner.
+# This sentinel forces a destroy+create on any vcn_cidr change so the new
+# instance always lands in a freshly-allocated VCN.
+resource "terraform_data" "vcn_cidr_marker" {
+  input = var.vcn_cidr
+}
+
 resource "oci_core_vcn" "edge" {
   compartment_id = local.oci_compartment_ocid
   display_name   = "edge-vcn"
   cidr_blocks    = [var.vcn_cidr]
   dns_label      = "edgevcn"
+
+  lifecycle {
+    replace_triggered_by = [terraform_data.vcn_cidr_marker]
+  }
 }
 
 resource "oci_core_internet_gateway" "edge" {

--- a/cloud-edge/network.tf
+++ b/cloud-edge/network.tf
@@ -1,8 +1,3 @@
-# OCI's UpdateVcn API treats cidr_blocks as updateable in-place, so a CIDR
-# change keeps the same VCN OCID. Empirically that "VCN reuse" leaves new
-# instances with sshd that accepts TCP but never exchanges the SSH banner.
-# This sentinel forces a destroy+create on any vcn_cidr change so the new
-# instance always lands in a freshly-allocated VCN.
 resource "terraform_data" "vcn_cidr_marker" {
   input = var.vcn_cidr
 }

--- a/cloud-edge/variables.tf
+++ b/cloud-edge/variables.tf
@@ -93,13 +93,13 @@ variable "ssh_public_key" {
 variable "vcn_cidr" {
   description = "CIDR block for the VCN"
   type        = string
-  default     = "10.75.0.0/16"
+  default     = "10.80.0.0/16"
 }
 
 variable "public_subnet_cidr" {
   description = "CIDR block for the public subnet"
   type        = string
-  default     = "10.75.1.0/24"
+  default     = "10.80.1.0/24"
 }
 
 variable "cloudflare_api_token" {


### PR DESCRIPTION
## Summary

Two coupled fixes for the OCI VCN-reuse trap that's been blocking the edge bring-up:

1. **\`vcn_cidr\` 10.75 → 10.80** (matching \`public_subnet_cidr\` and \`02-infrastructure/cloud_vcn_cidr\`). The 10.75 VCN was reused once already and now produces instances with sshd that accepts TCP but never sends the SSH banner. Empirically the only fix is a fresh CIDR + fresh VCN OCID.

2. **\`terraform_data\` sentinel** keyed to \`var.vcn_cidr\` and referenced from \`oci_core_vcn.edge.lifecycle.replace_triggered_by\`. OCI's \`UpdateVcn\` API treats \`cidr_blocks\` as updateable in-place — so a CIDR change alone keeps the same VCN OCID, which is the actual reuse trap. The sentinel forces destroy+create on any future CIDR change. The existing \`replace_triggered_by\` chain on subnet and instance then cascades correctly.

## Recovery flow once this lands

1. Merge.
2. Workflow_dispatch \`Cloud Edge\` with \`apply = true\`. No \`replace_target\` needed — the sentinel detects the CIDR change and plans a VCN replacement automatically.
3. Cascade: instance → subnet → IGW/route table/security list → VCN → recreate everything → new public IP → Cloudflare A record auto-updates from \`oci_core_instance.edge.public_ip\` (300s TTL).
4. Watch for orphan service VNICs blocking subnet destroy (rare now since k3s-services is gone, but check OCI console if the destroy hangs >2 min).

## Test plan

- [ ] After apply, \`nc -vz <new-ip> 22\` succeeds AND \`ssh-keyscan -t ed25519 <new-ip>\` returns a key (proves sshd is live, not just the TCP listener).
- [ ] \`nixos-anywhere\` install proceeds and the workflow finishes through \`Wait for WireGuard tunnel\`.
- [ ] HAProxy on the new edge serves \`https://dns.relay.lippok.dev/<token>/dns-query\` end-to-end (DoH passthrough to Blocky).
- [ ] On a future no-op apply, no spurious VCN replacement is planned (the \`terraform_data\` only fires when \`vcn_cidr\` actually changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)