### PR TITLE
fix(workflow): restart tailscaled-autoconnect after key deploy

### DIFF
--- a/cloud-edge/scripts/gha/cloud-edge-workflow.sh
+++ b/cloud-edge/scripts/gha/cloud-edge-workflow.sh
@@ -405,6 +405,11 @@ deploy_tailscale_credentials() {
     chmod 644 /etc/tailscale/subnet-cidr
   ' <<< "$subnet_cidr"
 
+  # tailscaled-autoconnect runs once at boot guarded by ConditionPathExists on
+  # the authkey file. On a fresh install the file doesn't exist yet, so the
+  # unit goes to skipped+exited state. Restarting it now picks up the keys.
+  ssh "${ssh_opts[@]}" "root@$IP" 'systemctl restart tailscaled-autoconnect.service'
+
   echo "Tailscale credentials and subnet CIDR deployed."
 }
 

--- a/cloud-edge/scripts/gha/cloud-edge-workflow.sh
+++ b/cloud-edge/scripts/gha/cloud-edge-workflow.sh
@@ -405,9 +405,7 @@ deploy_tailscale_credentials() {
     chmod 644 /etc/tailscale/subnet-cidr
   ' <<< "$subnet_cidr"
 
-  # tailscaled-autoconnect runs once at boot guarded by ConditionPathExists on
-  # the authkey file. On a fresh install the file doesn't exist yet, so the
-  # unit goes to skipped+exited state. Restarting it now picks up the keys.
+  # Restarting to pick up the authkey file.
   ssh "${ssh_opts[@]}" "root@$IP" 'systemctl restart tailscaled-autoconnect.service'
 
   echo "Tailscale credentials and subnet CIDR deployed."


### PR DESCRIPTION
## Summary
- \`tailscaled-autoconnect.service\` is guarded by \`ConditionPathExists=/etc/tailscale/authkey\`. On a fresh install the file isn't there at boot — unit goes to **skipped+exited** and stays that way. CI writes the key right after but nothing re-triggers the unit, so \`tailscale status\` reports \`NeedsLogin\` forever and \`wait-for-tailscale\` fails after 30 attempts.
- Add a \`systemctl restart tailscaled-autoconnect.service\` at the end of \`deploy-tailscale-credentials\` so the unit re-evaluates the condition with the keys in place.

## Test plan
- [ ] Re-run the cloud-edge workflow on the new VM — \`Wait for Tailscale to connect\` succeeds within the existing 30 attempts.
- [ ] On the edge: \`systemctl status tailscaled-autoconnect\` shows the unit completed cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)