### PR TITLE
fix(mesh-router): pull WG peer endpoint from cloud-edge remote state

### DIFF
--- a/.github/workflows/02-infrastructure.yaml
+++ b/.github/workflows/02-infrastructure.yaml
@@ -55,7 +55,6 @@ jobs:
       TF_VAR_mesh_router_root_password: ${{ secrets.MESH_ROUTER_ROOT_PASSWORD }}
       TF_VAR_mesh_wg_private_key: ${{ secrets.MESH_ROUTER_WG_PRIVATE_KEY }}
       TF_VAR_mesh_wg_peer_pubkey: ${{ vars.CLOUD_WG_PUBKEY }}
-      TF_VAR_mesh_wg_peer_endpoint: ${{ vars.CLOUD_WG_ENDPOINT }}
 
     steps:
       - name: Checkout Code

--- a/02-infrastructure/data.tf
+++ b/02-infrastructure/data.tf
@@ -51,8 +51,7 @@ locals {
   mesh_router_ip  = lookup(local.host_ips, "mesh_router", "10.10.1.90")
   mesh_router_mac = try(local.host_vm_macs.mesh_router, null)
 
-  # WireGuard endpoint of the cloud-edge — pulled from cloud-edge state so
-  # the mesh-router config follows whatever public IP OCI hands out.
+  # WireGuard endpoint of the cloud-edge
   mesh_wg_peer_endpoint = "${data.terraform_remote_state.cloud_edge.outputs.instance_public_ip}:51820"
 
   # Resolve MACs from 01-network outputs

--- a/02-infrastructure/data.tf
+++ b/02-infrastructure/data.tf
@@ -8,6 +8,16 @@ data "terraform_remote_state" "network" {
   }
 }
 
+data "terraform_remote_state" "cloud_edge" {
+  backend = "s3"
+
+  config = {
+    bucket = "finnpl-homelab-tfstate-1766068376"
+    key    = "cloud-edge/terraform.tfstate"
+    region = "eu-central-1"
+  }
+}
+
 locals {
   # Network configuration from 01-network
   athena_network = data.terraform_remote_state.network.outputs.athena_network
@@ -40,6 +50,10 @@ locals {
   # Mesh router
   mesh_router_ip  = lookup(local.host_ips, "mesh_router", "10.10.1.90")
   mesh_router_mac = try(local.host_vm_macs.mesh_router, null)
+
+  # WireGuard endpoint of the cloud-edge — pulled from cloud-edge state so
+  # the mesh-router config follows whatever public IP OCI hands out.
+  mesh_wg_peer_endpoint = "${data.terraform_remote_state.cloud_edge.outputs.instance_public_ip}:51820"
 
   # Resolve MACs from 01-network outputs
   talos_controlplane_mac = try(local.host_vm_macs.talos_controlplane, null)

--- a/02-infrastructure/mesh-router.tf
+++ b/02-infrastructure/mesh-router.tf
@@ -1,8 +1,5 @@
 # WireGuard subnet router for the cloud-edge and homelab relay path.
 
-# The provisioner below only runs at create time, so when the cloud-edge public
-# IP changes, the LXC's wg0.conf is stale until something replaces the LXC.
-# This sentinel forces replacement on any peer-endpoint change.
 resource "terraform_data" "mesh_wg_peer_endpoint_marker" {
   input = local.mesh_wg_peer_endpoint
 }

--- a/02-infrastructure/mesh-router.tf
+++ b/02-infrastructure/mesh-router.tf
@@ -1,5 +1,12 @@
 # WireGuard subnet router for the cloud-edge and homelab relay path.
 
+# The provisioner below only runs at create time, so when the cloud-edge public
+# IP changes, the LXC's wg0.conf is stale until something replaces the LXC.
+# This sentinel forces replacement on any peer-endpoint change.
+resource "terraform_data" "mesh_wg_peer_endpoint_marker" {
+  input = local.mesh_wg_peer_endpoint
+}
+
 resource "proxmox_virtual_environment_container" "mesh_router" {
   description = "WireGuard subnet router for clustermesh"
 
@@ -68,6 +75,10 @@ resource "proxmox_virtual_environment_container" "mesh_router" {
 
   tags = sort(["terraform", "wireguard", "clustermesh"])
 
+  lifecycle {
+    replace_triggered_by = [terraform_data.mesh_wg_peer_endpoint_marker]
+  }
+
   connection {
     type        = "ssh"
     user        = "root"
@@ -80,7 +91,7 @@ resource "proxmox_virtual_environment_container" "mesh_router" {
     content = templatefile("${path.module}/templates/mesh-wg0.conf", {
       private_key    = var.mesh_wg_private_key
       peer_pubkey    = var.mesh_wg_peer_pubkey
-      peer_endpoint  = var.mesh_wg_peer_endpoint
+      peer_endpoint  = local.mesh_wg_peer_endpoint
       cloud_vcn_cidr = var.cloud_vcn_cidr
     })
     destination = "/tmp/wg0.conf"

--- a/02-infrastructure/mesh-router.tf
+++ b/02-infrastructure/mesh-router.tf
@@ -1,7 +1,7 @@
 # WireGuard subnet router for the cloud-edge and homelab relay path.
 
 resource "terraform_data" "mesh_wg_peer_endpoint_marker" {
-  input = local.mesh_wg_peer_endpoint
+  triggers_replace = local.mesh_wg_peer_endpoint
 }
 
 resource "proxmox_virtual_environment_container" "mesh_router" {

--- a/02-infrastructure/variables.tf
+++ b/02-infrastructure/variables.tf
@@ -277,11 +277,6 @@ variable "mesh_wg_peer_pubkey" {
   type        = string
 }
 
-variable "mesh_wg_peer_endpoint" {
-  description = "WireGuard endpoint of the cloud-edge node (IP:port)"
-  type        = string
-}
-
 variable "cloud_vcn_cidr" {
   description = "CIDR of the OCI cloud-edge VCN (routed through WG tunnel)"
   type        = string


### PR DESCRIPTION
## Summary

The WG peer endpoint on mesh-router was a manually-bumped GitHub repo variable \`CLOUD_WG_ENDPOINT\`. When cloud-edge cycles its public IP (VCN replacement, instance recreate, etc.) the variable goes stale: mesh-router's \`wg0.conf\` gets baked with the old endpoint at provisioning time, the new edge never gets a WG handshake, and the relay path (HAProxy → wg0 → Blocky) silently collapses.

This PR makes mesh-router pull the endpoint from cloud-edge directly:

1. New \`terraform_remote_state.cloud_edge\` reference in [02-infrastructure/data.tf](02-infrastructure/data.tf), reading from \`s3://.../cloud-edge/terraform.tfstate\`.
2. \`local.mesh_wg_peer_endpoint = "\${...instance_public_ip}:51820"\`, fed into the \`mesh-wg0.conf\` template.
3. \`terraform_data.mesh_wg_peer_endpoint_marker\` sentinel keyed to that endpoint, referenced by the LXC's \`lifecycle.replace_triggered_by\` — provisioner only runs at create-time, so the LXC must be replaced for \`wg0.conf\` to be re-rendered.
4. Drop the unused \`mesh_wg_peer_endpoint\` variable and the \`TF_VAR_mesh_wg_peer_endpoint\` env line in 02-infrastructure.yaml.

After merge, the \`CLOUD_WG_ENDPOINT\` GitHub repo variable can be deleted.

## Test plan
- [ ] Apply 02-infrastructure: plan shows mesh-router replacement (because \`endpoint marker\` flips from old IP to new IP) and nothing else.
- [ ] After apply: \`ssh root@10.10.1.90 cat /etc/wireguard/wg0.conf\` shows \`Endpoint = 92.5.163.85:51820\`.
- [ ] On edge: \`wg show wg0\` shows \`latest handshake\` populated and \`transfer\` non-zero within 25s.
- [ ] \`curl -kI --resolve dns.relay.lippok.dev:443:92.5.163.85 https://dns.relay.lippok.dev/ -m 10\` returns a real TLS response (Blocky's cert + a Blocky HTTP status).
- [ ] On a future cloud-edge IP cycle: 02-infra plan auto-replaces mesh-router, no manual variable bump needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)