### PR TITLE
fix(kyverno): unbreak ArgoCD sync — bump to 3.8.0, drop dead bitnami image, escape JMESPath

### DIFF
--- a/apps/kyverno-operator.yaml
+++ b/apps/kyverno-operator.yaml
@@ -12,7 +12,7 @@ spec:
   source:
     repoURL: https://kyverno.github.io/kyverno/
     chart: kyverno
-    targetRevision: 3.3.7
+    targetRevision: 3.8.0
     helm:
       values: |
         features:
@@ -39,11 +39,10 @@ spec:
             limits:
               memory: 384Mi
           container:
+            # Flip forceFailurePolicyIgnore to "false" once confident in the policy set.
             extraArgs:
               webhookTimeout: "10"
-          # Flip to Fail once confident in the policy set.
-          webhooks:
-            - failurePolicy: Ignore
+              forceFailurePolicyIgnore: "true"
         backgroundController:
           replicas: 1
           priorityClassName: system-cluster-critical

--- a/charts/kyverno/Chart.yaml
+++ b/charts/kyverno/Chart.yaml
@@ -3,5 +3,5 @@ name: kyverno
 version: 1.0.0
 dependencies:
   - name: kyverno-policies
-    version: "3.3.7"
+    version: "3.8.0"
     repository: "https://kyverno.github.io/kyverno/"

--- a/charts/kyverno/templates/check-deprecated-apis.yaml
+++ b/charts/kyverno/templates/check-deprecated-apis.yaml
@@ -18,11 +18,11 @@ spec:
               kinds:
                 - "*"
       validate:
-        message: "API version '{{ request.object.apiVersion }}' is deprecated or removed. Migrate to the stable API."
+        message: "API version '{{ `{{ request.object.apiVersion }}` }}' is deprecated or removed. Migrate to the stable API."
         deny:
           conditions:
             any:
-              - key: "{{ request.object.apiVersion }}"
+              - key: "{{ `{{ request.object.apiVersion }}` }}"
                 operator: In
                 value:
                   - extensions/v1beta1

--- a/charts/kyverno/templates/disallow-default-namespace.yaml
+++ b/charts/kyverno/templates/disallow-default-namespace.yaml
@@ -23,6 +23,6 @@ spec:
         deny:
           conditions:
             any:
-              - key: "{{ request.namespace }}"
+              - key: "{{ `{{ request.namespace }}` }}"
                 operator: Equals
                 value: default

--- a/charts/kyverno/templates/disallow-latest-tag.yaml
+++ b/charts/kyverno/templates/disallow-latest-tag.yaml
@@ -24,29 +24,29 @@ spec:
             deny:
               conditions:
                 any:
-                  - key: "{{ element.image }}"
+                  - key: "{{ `{{ element.image }}` }}"
                     operator: AnyIn
                     value: ["*:latest"]
-                  - key: "{{ element.image }}"
+                  - key: "{{ `{{ element.image }}` }}"
                     operator: NotContains
                     value: ":"
           - list: "request.object.spec.initContainers || `[]`"
             deny:
               conditions:
                 any:
-                  - key: "{{ element.image }}"
+                  - key: "{{ `{{ element.image }}` }}"
                     operator: AnyIn
                     value: ["*:latest"]
-                  - key: "{{ element.image }}"
+                  - key: "{{ `{{ element.image }}` }}"
                     operator: NotContains
                     value: ":"
           - list: "request.object.spec.ephemeralContainers || `[]`"
             deny:
               conditions:
                 any:
-                  - key: "{{ element.image }}"
+                  - key: "{{ `{{ element.image }}` }}"
                     operator: AnyIn
                     value: ["*:latest"]
-                  - key: "{{ element.image }}"
+                  - key: "{{ `{{ element.image }}` }}"
                     operator: NotContains
                     value: ":"

--- a/charts/kyverno/templates/require-resource-limits.yaml
+++ b/charts/kyverno/templates/require-resource-limits.yaml
@@ -25,29 +25,29 @@ spec:
             deny:
               conditions:
                 any:
-                  - key: "{{ element.resources.limits.memory || '' }}"
+                  - key: "{{ `{{ element.resources.limits.memory || '' }}` }}"
                     operator: Equals
                     value: ""
-                  - key: "{{ element.resources.limits.cpu || '' }}"
+                  - key: "{{ `{{ element.resources.limits.cpu || '' }}` }}"
                     operator: Equals
                     value: ""
           - list: "request.object.spec.initContainers || `[]`"
             deny:
               conditions:
                 any:
-                  - key: "{{ element.resources.limits.memory || '' }}"
+                  - key: "{{ `{{ element.resources.limits.memory || '' }}` }}"
                     operator: Equals
                     value: ""
-                  - key: "{{ element.resources.limits.cpu || '' }}"
+                  - key: "{{ `{{ element.resources.limits.cpu || '' }}` }}"
                     operator: Equals
                     value: ""
           - list: "request.object.spec.ephemeralContainers || `[]`"
             deny:
               conditions:
                 any:
-                  - key: "{{ element.resources.limits.memory || '' }}"
+                  - key: "{{ `{{ element.resources.limits.memory || '' }}` }}"
                     operator: Equals
                     value: ""
-                  - key: "{{ element.resources.limits.cpu || '' }}"
+                  - key: "{{ `{{ element.resources.limits.cpu || '' }}` }}"
                     operator: Equals
                     value: ""

--- a/charts/kyverno/templates/require-ro-rootfs.yaml
+++ b/charts/kyverno/templates/require-ro-rootfs.yaml
@@ -25,20 +25,20 @@ spec:
             deny:
               conditions:
                 any:
-                  - key: "{{ element.securityContext.readOnlyRootFilesystem || false }}"
+                  - key: "{{ `{{ element.securityContext.readOnlyRootFilesystem || false }}` }}"
                     operator: Equals
                     value: false
           - list: "request.object.spec.initContainers || `[]`"
             deny:
               conditions:
                 any:
-                  - key: "{{ element.securityContext.readOnlyRootFilesystem || false }}"
+                  - key: "{{ `{{ element.securityContext.readOnlyRootFilesystem || false }}` }}"
                     operator: Equals
                     value: false
           - list: "request.object.spec.ephemeralContainers || `[]`"
             deny:
               conditions:
                 any:
-                  - key: "{{ element.securityContext.readOnlyRootFilesystem || false }}"
+                  - key: "{{ `{{ element.securityContext.readOnlyRootFilesystem || false }}` }}"
                     operator: Equals
                     value: false


### PR DESCRIPTION
## Summary
- Bump `kyverno-policies` dep and `kyverno` operator chart `3.3.7` → `3.8.0`. `3.3.7` of `kyverno-policies` was never published, so `helm dependency build` failed in ArgoCD. The operator bump also retires the deleted `bitnami/kubectl:1.30.2` image used by the `policyReportsCleanup` PostSync hook — upstream moved to `reg.kyverno.io/kyverno/kyverno-cli` in chart 3.4+.
- Replace the dead `admissionController.webhooks[].failurePolicy: Ignore` override (that values path was removed in chart ≥3.4) with `--forceFailurePolicyIgnore=true` via `admissionController.container.extraArgs`. Preserves the original "if Kyverno is down, allow admissions" behavior under v1.18.
- Escape every Kyverno `{{ ... }}` JMESPath expression in the policy templates using Helm's raw-string idiom (`{{ \`{{ ... }}\` }}`). Without this, Helm tries to evaluate `element` / `request.*` as Go-template references and rendering fails — the chart had never been able to render.

## Test plan
- [x] `helm dependency update charts/kyverno` resolves cleanly.
- [x] `helm template charts/kyverno` renders with no errors; Kyverno expressions appear verbatim in rendered output.
- [x] `helm template kyverno/kyverno --version 3.8.0 -f <values>` shows `--forceFailurePolicyIgnore=true` and `--webhookTimeout=10` in the admission-controller args, no `bitnami/kubectl` images anywhere.
- [ ] ArgoCD sync for the `kyverno-operator` and `kyverno` Applications completes Healthy.
- [ ] `kubectl get clusterpolicy disallow-default-namespace -o yaml` shows the autogen rules use `request.namespace`, and a `kubectl run -n default test --image=nginx` is reported as a policy violation in audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)