### PR TITLE
fix(kyverno): use AnyNotIn wildcard instead of unsupported NotContains operator

### DIFF
--- a/charts/kyverno/templates/disallow-latest-tag.yaml
+++ b/charts/kyverno/templates/disallow-latest-tag.yaml
@@ -28,8 +28,8 @@ spec:
                     operator: AnyIn
                     value: ["*:latest"]
                   - key: "{{ `{{ element.image }}` }}"
-                    operator: NotContains
-                    value: ":"
+                    operator: AnyNotIn
+                    value: ["*:*"]
           - list: "request.object.spec.initContainers || `[]`"
             deny:
               conditions:
@@ -38,8 +38,8 @@ spec:
                     operator: AnyIn
                     value: ["*:latest"]
                   - key: "{{ `{{ element.image }}` }}"
-                    operator: NotContains
-                    value: ":"
+                    operator: AnyNotIn
+                    value: ["*:*"]
           - list: "request.object.spec.ephemeralContainers || `[]`"
             deny:
               conditions:
@@ -48,5 +48,5 @@ spec:
                     operator: AnyIn
                     value: ["*:latest"]
                   - key: "{{ `{{ element.image }}` }}"
-                    operator: NotContains
-                    value: ":"
+                    operator: AnyNotIn
+                    value: ["*:*"]


### PR DESCRIPTION
## Summary
Kyverno v1.18's validating webhook rejected `disallow-latest-tag` with:

> entered value of \`operator\` is invalid. valid values: ["DurationLessThanOrEquals" "Equal" "NotEquals" "In" ... "AnyIn" "NotIn"]

`NotContains` is not on that list. Expressing "image has no tag separator" via the wildcard-aware `AnyNotIn` against `*:*` achieves the same intent with a supported operator.

Follow-up to #553 — surfaced once the chart actually started rendering and policies hit the webhook.

## Test plan
- [x] `helm template charts/kyverno` renders without error.
- [x] Every `operator:` used across the local policies (`AnyIn`, `AnyNotIn`, `Equals`, `In`) is in v1.18's valid set.
- [ ] After sync, `kubectl apply` a Pod with `image: nginx` (no tag) is reported as a policy violation in audit.
- [ ] A Pod with `image: nginx:latest` is still reported.
- [ ] A Pod with `image: nginx:1.29` is allowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)