### PR TITLE
fix(kyverno): annotate CRDs with ServerSideApply to bypass ArgoCD 256KB annotation limit

### DIFF
--- a/apps/kyverno-operator.yaml
+++ b/apps/kyverno-operator.yaml
@@ -15,6 +15,9 @@ spec:
     targetRevision: 3.8.0
     helm:
       values: |
+        crds:
+          annotations:
+            argocd.argoproj.io/sync-options: ServerSideApply=true
         features:
           policyExceptions:
             enabled: true


### PR DESCRIPTION
## Summary
Kyverno v1.18 CRDs render to ~1.4 MB. ArgoCD's client-side apply writes the full object into `kubectl.kubernetes.io/last-applied-configuration` and exceeds Kubernetes' 256KB per-annotation cap. The app-level `ServerSideApply=true` syncOption is not honored on the CRD apply path in this setup (controller logs show `serverSideApply: false` for CRDs).

Use the chart's `crds.annotations` value to stamp each CRD with the per-resource `argocd.argoproj.io/sync-options: ServerSideApply=true` annotation that ArgoCD does honor.

## Test plan
- [x] `kubectl apply --server-side` on the rendered CRDs works directly (validated manually before the fix).
- [ ] After ArgoCD syncs this change, `kyverno-operator` reaches `Synced + Healthy`.
- [ ] `kyverno` (policies) Application reaches `Synced + Healthy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)