### PR TITLE
fix(kyverno,alloy): disable background scan on custom policies; add fsGroup for alloy emptyDir

### DIFF
--- a/charts/alloy/values.yaml
+++ b/charts/alloy/values.yaml
@@ -1,5 +1,12 @@
 alloy-agent:
   enabled: true
+  # alloy image runs as uid/gid 473; with readOnlyRootFilesystem + the
+  # /var/lib/alloy/data emptyDir, kubelet needs fsGroup to chgrp the tmpfs
+  # so alloy can write to it.
+  global:
+    podSecurityContext:
+      fsGroup: 473
+      fsGroupChangePolicy: OnRootMismatch
   configReloader:
     securityContext:
       readOnlyRootFilesystem: true
@@ -223,6 +230,10 @@ alloy-agent:
 
 alloy-receiver:
   enabled: true
+  global:
+    podSecurityContext:
+      fsGroup: 473
+      fsGroupChangePolicy: OnRootMismatch
   configReloader:
     securityContext:
       readOnlyRootFilesystem: true

--- a/charts/kyverno/templates/disallow-default-namespace.yaml
+++ b/charts/kyverno/templates/disallow-default-namespace.yaml
@@ -10,7 +10,7 @@ metadata:
       namespace-scoped RBAC and network policies cleanly.
 spec:
   validationFailureAction: Audit
-  background: true
+  background: false
   rules:
     - name: check-default-namespace
       match:

--- a/charts/kyverno/templates/disallow-latest-tag.yaml
+++ b/charts/kyverno/templates/disallow-latest-tag.yaml
@@ -9,7 +9,7 @@ metadata:
       Using the :latest tag prevents reproducible rollbacks.
 spec:
   validationFailureAction: Audit
-  background: true
+  background: false
   rules:
     - name: require-image-tag
       match:

--- a/charts/kyverno/templates/require-resource-limits.yaml
+++ b/charts/kyverno/templates/require-resource-limits.yaml
@@ -10,7 +10,7 @@ metadata:
       CPU limits are intentionally NOT required.
 spec:
   validationFailureAction: Audit
-  background: true
+  background: false
   rules:
     - name: require-limits
       match:

--- a/charts/kyverno/templates/require-ro-rootfs.yaml
+++ b/charts/kyverno/templates/require-ro-rootfs.yaml
@@ -10,7 +10,7 @@ metadata:
       image layer, limiting the blast radius of a compromised container.
 spec:
   validationFailureAction: Audit
-  background: true
+  background: false
   rules:
     - name: require-ro-rootfs
       match:


### PR DESCRIPTION
## Summary

Two follow-up fixes after PR #562:

### Kyverno: 4 custom policies still doing background scan
The `kyverno-policies` subchart's `background: false` only applies to its own templates. Our 5 custom policies in `charts/kyverno/templates/` each have `spec.background` hardcoded. `check-deprecated-apis` was already `false`; the other 4 were still `true`, so they kept running background scans after PR #562 merged.

### Alloy: pods crashing with `mkdir /var/lib/alloy/data: permission denied`
The alloy chart enforces `readOnlyRootFilesystem: true` and the upstream image runs as uid/gid 473. The `/var/lib/alloy/data` `emptyDir: medium: Memory` mount is owned by root:root, so alloy (non-root) cannot write. Discovered when the DaemonSet rolled and the new pod on `talos-4ut-tyx` crash-looped — the other 3 pods (20 days old) are running the pre-rollout spec without RO rootfs, so they're unaffected for now. Fix is `global.podSecurityContext.fsGroup: 473` + `fsGroupChangePolicy: OnRootMismatch`, applied to both alloy-agent and alloy-receiver.

## Test plan
- [ ] After merge → ArgoCD sync → kyverno policies show `background: false` on all 16 ClusterPolicies
- [ ] Verify `kubectl get polr -A` count stays stable (no new background-generated reports)
- [ ] alloy-alloy-agent DaemonSet completes its rollout — all 4 pods 2/2 Ready
- [ ] alloy-alloy-receiver StatefulSet pod 1/1 → 2/2 Ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)