### PR TITLE
fix(alloy): mount writable /tmp for remotecfg; add storage volumes to receiver

### DIFF
--- a/charts/alloy/values.yaml
+++ b/charts/alloy/values.yaml
@@ -261,6 +261,8 @@ alloy-receiver:
     extraArgs:
       - --disable-reporting
 
+    storagePath: /var/lib/alloy/data
+
     # rootfs is RO; alloy needs writable /var/lib/alloy/data (storage)
     # and /tmp (remotecfg cache).
     mounts:

--- a/charts/alloy/values.yaml
+++ b/charts/alloy/values.yaml
@@ -40,6 +40,9 @@ alloy-agent:
       extra:
         - name: alloy-data
           mountPath: /var/lib/alloy/data
+        # /tmp must be writable for alloy's remotecfg cache; rootfs is RO
+        - name: alloy-tmp
+          mountPath: /tmp
 
         - name: varlogpods
           mountPath: /var/log/pods
@@ -221,6 +224,10 @@ alloy-agent:
           emptyDir:
             medium: Memory
             sizeLimit: 100Mi
+        - name: alloy-tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 50Mi
         - name: varlogpods
           hostPath:
             path: /var/log/pods
@@ -254,6 +261,15 @@ alloy-receiver:
     extraArgs:
       - --disable-reporting
 
+    # rootfs is RO; alloy needs writable /var/lib/alloy/data (storage)
+    # and /tmp (remotecfg cache).
+    mounts:
+      extra:
+        - name: alloy-data
+          mountPath: /var/lib/alloy/data
+        - name: alloy-tmp
+          mountPath: /tmp
+
     configMap:
       content: |
         logging {
@@ -282,6 +298,16 @@ alloy-receiver:
   controller:
     type: statefulset
     replicas: 1
+    volumes:
+      extra:
+        - name: alloy-data
+          emptyDir:
+            medium: Memory
+            sizeLimit: 100Mi
+        - name: alloy-tmp
+          emptyDir:
+            medium: Memory
+            sizeLimit: 50Mi
     nodeSelector:
       dedicated: "database"
     tolerations:


### PR DESCRIPTION
## Summary
- Add `/tmp` emptyDir mount (50 MiB tmpfs) to both alloy-agent and alloy-receiver
- Add `/var/lib/alloy/data` emptyDir to alloy-receiver (it had no writable storage path)

## Background
After PR #563 fixed the fsGroup issue for `/var/lib/alloy/data`, alloy-agent pods started successfully. But alloy-receiver started crashing with:

```
mkdir /tmp/alloy: read-only file system
```

The chart sets `readOnlyRootFilesystem: true` on the alloy container. Alloy's remotecfg service caches state under `/tmp/alloy` which is on the (now RO) container rootfs. The receiver also had no `alloy-data` volume defined at all — agent had one, receiver didn't.

## Test plan
- [ ] After merge → ArgoCD sync → alloy-alloy-receiver-0 reaches 2/2 Ready
- [ ] alloy-alloy-agent DaemonSet remaining pod rolls and stays Ready
- [ ] No StatefulSetReplicasMismatch alert

🤖 Generated with [Claude Code](https://claude.com/claude-code)