### PR TITLE
fix(kyverno): scope check-deprecated-apis to specific kinds

### DIFF
--- a/charts/kyverno/templates/check-deprecated-apis.yaml
+++ b/charts/kyverno/templates/check-deprecated-apis.yaml
@@ -16,7 +16,16 @@ spec:
         any:
           - resources:
               kinds:
-                - "*"
+                - Deployment
+                - DaemonSet
+                - StatefulSet
+                - ReplicaSet
+                - Ingress
+                - IngressClass
+                - NetworkPolicy
+                - PodDisruptionBudget
+                - CronJob
+                - HorizontalPodAutoscaler
       validate:
         message: "API version '{{ `{{ request.object.apiVersion }}` }}' is deprecated or removed. Migrate to the stable API."
         deny:


### PR DESCRIPTION
## Summary
- `check-deprecated-apis` matched `kinds: ['*']`. Every admission event (including PolicyReport writes) hit the rule, which then produced another report — feedback loop.
- Cluster was accumulating PolicyReports at ~7/sec (1342 → 1759 in 60s, 1800+ total), causing apiserver memory pressure and etcd churn on the 3.8GB control-plane node.
- Scope match to the kinds that actually have deprecated API versions in the deny list. `background: false` already disabled the periodic scan; this kills the admission-path recursion.

## Test plan
- [ ] Argo sync lands the change; webhook reloads
- [ ] No new PolicyReports created for `PolicyReport`/`EphemeralReport` kinds
- [ ] After bulk-deleting existing stale reports, apiserver RSS drops on talos-8vk-gus

🤖 Generated with [Claude Code](https://claude.com/claude-code)