### PR TITLE
fix(monitoring): unbreak alloy + loki pod admission under restricted PSS

### DIFF
--- a/charts/alloy/values.yaml
+++ b/charts/alloy/values.yaml
@@ -1,13 +1,9 @@
 alloy-agent:
   enabled: true
-  # alloy image runs as uid/gid 473; with readOnlyRootFilesystem + the
-  # /var/lib/alloy/data emptyDir, kubelet needs fsGroup to chgrp the tmpfs
-  # so alloy can write to it.
   global:
     podSecurityContext:
       fsGroup: 473
       fsGroupChangePolicy: OnRootMismatch
-      runAsNonRoot: true
       seccompProfile:
         type: RuntimeDefault
   configReloader:
@@ -21,6 +17,7 @@ alloy-agent:
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
       runAsNonRoot: true
+      runAsUser: 65534
       capabilities:
         drop: ["ALL"]
       seccompProfile:
@@ -37,7 +34,6 @@ alloy-agent:
     securityContext:
       readOnlyRootFilesystem: true
       allowPrivilegeEscalation: false
-      runAsNonRoot: true
       capabilities:
         drop: ["ALL"]
       seccompProfile:
@@ -257,6 +253,8 @@ alloy-receiver:
       fsGroup: 473
       fsGroupChangePolicy: OnRootMismatch
       runAsNonRoot: true
+      runAsUser: 473
+      runAsGroup: 473
       seccompProfile:
         type: RuntimeDefault
   configReloader:

--- a/charts/kyverno/templates/policy-exceptions.yaml
+++ b/charts/kyverno/templates/policy-exceptions.yaml
@@ -306,7 +306,8 @@ metadata:
     policies.kyverno.io/description: >-
       alloy-agent is a hostNetwork DaemonSet that binds syslog hostPorts
       (5140/5141/5142) and mounts /var/log + /var/log/pods to tail container
-      logs for Loki.
+      logs for Loki. The alloy container runs as root because a non-root uid
+      cannot reliably read the root-owned host log files.
 spec:
   match:
     any:
@@ -324,6 +325,10 @@ spec:
       ruleNames: [host-path, autogen-host-path]
     - policyName: disallow-host-ports
       ruleNames: [host-ports-none, autogen-host-ports-none]
+    - policyName: require-run-as-nonroot
+      ruleNames: [run-as-non-root, autogen-run-as-non-root]
+    - policyName: require-run-as-non-root-user
+      ruleNames: [run-as-non-root-user, autogen-run-as-non-root-user]
     - policyName: restrict-volume-types
       ruleNames: [restricted-volumes, autogen-restricted-volumes]
 ---

--- a/charts/loki/values.yaml
+++ b/charts/loki/values.yaml
@@ -37,9 +37,9 @@ loki:
     resources:
       requests:
         cpu: 10m
-        memory: 32Mi
-      limits:
         memory: 64Mi
+      limits:
+        memory: 128Mi
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:


### PR DESCRIPTION
Follow-up to #571. Three workloads failed to start once the security hardening deployed:

| Workload | Failure | Root cause |
|---|---|---|
| alloy-agent / alloy-receiver | `CreateContainerConfigError` | `runAsNonRoot: true` with no numeric `runAsUser` — kubelet can't verify the `alloy` (USER root) or `config-reloader` (USER `nobody`) containers are non-root |
| loki (`loki-sc-rules` sidecar) | OOMKilled (loki itself healthy) | sidecar memory limit `64Mi` too low |

### Changes
- **alloy-agent** runs the `alloy` container as **root** — it tails root-owned host logs under `/var/log/pods` that a non-root uid can't reliably read. Keeps the rest of the restricted profile (drop ALL caps, no priv-esc, RO rootfs, RuntimeDefault seccomp); exempted from `require-run-as-nonroot` / `require-run-as-non-root-user` via the `monitoring-alloy-agent` PolicyException. The `config-reloader` sidecar gets a numeric `runAsUser: 65534`.
- **alloy-receiver** only reads the K8s events API, so both containers run as the non-root alloy uid **473** (pod `securityContext`).
- **loki** sidecar limit raised to **128Mi**.

### Verification
`helm template charts/alloy | kyverno apply` against the live policies + exceptions: **no failures** (all pass or exempted). Rendered securityContexts confirmed free of the `runAsNonRoot`-without-`runAsUser` condition that broke kubelet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)